### PR TITLE
ELY-1892: Remove rotate, crop, and scale from aruco_ros

### DIFF
--- a/aruco_msgs/CMakeLists.txt
+++ b/aruco_msgs/CMakeLists.txt
@@ -7,7 +7,7 @@ find_package(catkin REQUIRED COMPONENTS
   std_msgs
   sensor_msgs)
 
-add_message_files( FILES Marker.msg Corner.msg MarkerImage.msg )
+add_message_files( FILES Marker.msg Corner.msg MarkerImage.msg DetectionZone.msg )
 generate_messages( DEPENDENCIES std_msgs geometry_msgs sensor_msgs )
 
 catkin_package(

--- a/aruco_msgs/msg/DetectionZone.msg
+++ b/aruco_msgs/msg/DetectionZone.msg
@@ -1,0 +1,4 @@
+uint32 x
+uint32 y
+uint32 width
+uint32 height

--- a/aruco_msgs/msg/Marker.msg
+++ b/aruco_msgs/msg/Marker.msg
@@ -25,3 +25,4 @@ uint32 error_code
 string error_message
 geometry_msgs/PoseWithCovariance pose
 Corner[] corners
+DetectionZone detection_zone

--- a/aruco_msgs/msg/Marker.msg
+++ b/aruco_msgs/msg/Marker.msg
@@ -25,4 +25,3 @@ uint32 error_code
 string error_message
 geometry_msgs/PoseWithCovariance pose
 Corner[] corners
-DetectionZone detection_zone

--- a/aruco_msgs/msg/MarkerImage.msg
+++ b/aruco_msgs/msg/MarkerImage.msg
@@ -1,2 +1,3 @@
 Marker[] markers
 sensor_msgs/Image image
+DetectionZone detection_zone

--- a/aruco_ros/src/aruco_detector.cpp
+++ b/aruco_ros/src/aruco_detector.cpp
@@ -85,11 +85,7 @@ private:
   bool overlay_bounding_box;
   bool overlay_error_message;
 
-  bool rotate_image;
-  bool resize_image;
   bool crop_image;
-  int resize_width;
-  int resize_height;
   int crop_x;
   int crop_y;
   int crop_width;
@@ -252,11 +248,7 @@ public:
     nh.param<bool>("overlay_bounding_box", overlay_bounding_box, true);
     nh.param<bool>("overlay_error_message", overlay_error_message, true);
 
-    nh.param<bool>("rotate_image", rotate_image, false);
-    nh.param<bool>("resize_image", resize_image, false);
     nh.param<bool>("crop_image", crop_image, false);
-    nh.param<int>("resize_width", resize_width, -1);
-    nh.param<int>("resize_height", resize_height, -1);
     nh.param<int>("crop_x", crop_x, -1);
     nh.param<int>("crop_y", crop_y, -1);
     nh.param<int>("crop_width", crop_width, -1);
@@ -463,28 +455,16 @@ public:
         cv_ptr = cv_bridge::toCvCopy(msg, sensor_msgs::image_encodings::RGB8);
         inImage = cv_ptr->image;
 
-        // Resize image
-        if (resize_image && resize_width != -1 && resize_height != -1) {
-          cv::Size new_size(resize_width, resize_height);
-          cv::resize(inImage, inImage, new_size);
-        }
-
         // Crop image
         if (crop_image && crop_x != -1 && crop_y != -1 && crop_width != -1 && crop_height != -1) {
           cv::Rect crop_rect(crop_x, crop_y, crop_width, crop_height);
-          inImage = inImage(crop_rect);
-        }
-
-        // Rotate image
-        if (rotate_image) {
-          cv::rotate(inImage, inImage, cv::ROTATE_90_CLOCKWISE);
         }
 
         std::vector<aruco_msgs::Marker> markerMsgs;
         //detection results will go into "markers"
         markers.clear();
         //Ok, let's detect
-        mDetector.detect(inImage, markers, camParam, marker_size, false);
+        mDetector.detect(inImage(crop_rect), markers, camParam, marker_size, false);
         //for each marker, draw info and its boundaries in the image
 
         if (markers.size() == 1 && is_marker_id_in_list(markers[0].id)){

--- a/aruco_ros/src/aruco_detector.cpp
+++ b/aruco_ros/src/aruco_detector.cpp
@@ -85,11 +85,10 @@ private:
   bool overlay_bounding_box;
   bool overlay_error_message;
 
-  bool crop_image;
-  int crop_x;
-  int crop_y;
-  int crop_width;
-  int crop_height;
+  int detection_zone_x;
+  int detection_zone_y;
+  int detection_zone_width;
+  int detection_zone_height;
 
   cv::Point position;
 
@@ -248,11 +247,10 @@ public:
     nh.param<bool>("overlay_bounding_box", overlay_bounding_box, true);
     nh.param<bool>("overlay_error_message", overlay_error_message, true);
 
-    nh.param<bool>("crop_image", crop_image, false);
-    nh.param<int>("crop_x", crop_x, -1);
-    nh.param<int>("crop_y", crop_y, -1);
-    nh.param<int>("crop_width", crop_width, -1);
-    nh.param<int>("crop_height", crop_height, -1);
+    nh.param<int>("detection_zone_x", detection_zone_x, -1);
+    nh.param<int>("detection_zone_y", detection_zone_y, -1);
+    nh.param<int>("detection_zone_width", detection_zone_width, -1);
+    nh.param<int>("detection_zone_height", detection_zone_height, -1);
 
     ROS_ASSERT(camera_frame != "" && marker_frame != "");
     //ROS_ASSERT(num_markers_in_list <= 11);
@@ -460,7 +458,7 @@ public:
         markers.clear();
 
         // Only detect codes inside the detection zone
-        cv::Rect detection_zone(0, 0, camParam.width, camParam.height);
+        cv::Rect detection_zone(0, 0, camParam.CamSize.width, camParam.CamSize.height);
         if (detection_zone_x != -1 && detection_zone_y != -1 && detection_zone_width != -1 && detection_zone_height != -1) {
           detection_zone.x = detection_zone_x;
           detection_zone.y = detection_zone_y;
@@ -477,7 +475,6 @@ public:
           // Only process markers if there is only one known marker in FOV
           // only publishing the selected markers
           aruco_msgs::Marker markerMsg = process_marker(markers[0], curr_stamp);
-          markerMsg.detection_zone = detection_zone;
           markerMsgs.push_back(markerMsg);
         }else if (markers.size() > 1){
           // If multiple aruco code have been detected, return the error message
@@ -500,7 +497,6 @@ public:
           arucoMsg.header.stamp = curr_stamp;
           arucoMsg.error_code = aruco_msgs::Marker::MORE_THAN_ONE_CODE;
           arucoMsg.error_message = aruco_msgs::Marker::MORE_THAN_ONE_CODE_MESSAGE;
-          arucoMsg.detection_zone = detection_zone;
           pose_pub.publish(arucoMsg);
           markerMsgs.push_back(arucoMsg);
 
@@ -519,6 +515,10 @@ public:
           out_msg.image = inImage;
           markerImageMsg.image = *out_msg.toImageMsg();
           markerImageMsg.markers = markerMsgs;
+          markerImageMsg.detection_zone.x = detection_zone.x;
+          markerImageMsg.detection_zone.y = detection_zone.y;
+          markerImageMsg.detection_zone.width = detection_zone.width;
+          markerImageMsg.detection_zone.height = detection_zone.height;
 
           markerImage_pub.publish(markerImageMsg);
         }


### PR DESCRIPTION
Instead of manipulating the image inside of aruco detector (crop/rotate/scale), we define a detection zone within the image, and publish the zone information for other nodes to consume.